### PR TITLE
🛟 Arrumador: Configure standard CI and mise tooling

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -1,0 +1,52 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup mise
+        uses: jdx/mise-action@v2
+      - name: Install dependencies
+        run: mise run install
+      - name: Codegen
+        run: mise run codegen
+      - name: PR if differences
+        run: |
+          if [[ -n $(git status --porcelain) ]]; then
+            git config --global user.name 'github-actions[bot]'
+            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+            git checkout -b codegen-${GITHUB_SHA}
+            git add .
+            git commit -m "chore: update generated code"
+            git push -u origin codegen-${GITHUB_SHA} || true
+            gh pr create --title "chore: update generated code" --body "Auto-generated PR for codegen updates" --base ${GITHUB_REF#refs/heads/} --head codegen-${GITHUB_SHA} || true
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: CI
+        run: mise run ci
+      - name: Release
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        run: gh release create ${{ github.ref_name }} --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Artifacts
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        run: echo "No artifacts"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,27 @@
+[tools]
+"github:lucasew/workspaced" = "0.1.6"
+
+[tasks]
+lint = "workspaced codebase lint"
+fmt = "workspaced codebase format"
+
+[tasks.test]
+depends = ["test:*"]
+
+[tasks."test:dummy"]
+run = "true"
+
+[tasks.codegen]
+depends = ["codegen:*"]
+
+[tasks."codegen:dummy"]
+run = "true"
+
+[tasks.install]
+depends = ["install:*"]
+
+[tasks."install:dummy"]
+run = "true"
+
+[tasks.ci]
+depends = ["lint", "test"]


### PR DESCRIPTION
**Assumptions**
- The repository is a standard Python/Nix project with no active Vercel/Cloudflare deployments, so the `Release` and `Artifacts` steps were added.
- The project doesn't have an active `test` or `codegen` subtask configured yet, but `mise` needs them defined to use wildcard dependancies correctly, so dummy targets were provided.
- `workspaced` is pinned to `0.1.6` for determinism.

**Alternatives Not Chosen**
- Defining specific tests or linters directly within `mise.toml` instead of relying on `workspaced` and wildcards. This was avoided to stick to standardizing on `workspaced` for all linting and format needs as requested.

**How To Pivot**
- To change the testing framework or codegen implementation, modify or add specific subtasks (like `test:pytest` or `codegen:generate`) to `mise.toml`. `ci` will naturally pick them up.
- To disable automated releases, you can drop the `Release` and `Artifacts` steps from `.github/workflows/autorelease.yml`.

**Next Knobs**
- Update `.github/workflows/autorelease.yml` to handle artifact uploads correctly if Python wheel builds or binary releases are later added.
- Provide a `requirements.txt` or standard Python build process under an `install:pip` task in `mise.toml`.

---
*PR created automatically by Jules for task [9427998490292437929](https://jules.google.com/task/9427998490292437929) started by @lucasew*