### PR TITLE
🛠️ Refactor: Centralize error reporting and remove empty catch blocks

### DIFF
--- a/pdfnormalizer/app_boring_extract
+++ b/pdfnormalizer/app_boring_extract
@@ -45,10 +45,7 @@ class CustomGUIHandler(GUIHandler):
         if self.elem_ordering.get(self.page) is None:
             self.elem_ordering[self.page] = [elem]
         if sub is None:
-            try:
-                self.known_elements[self.page].pop(k)
-            except KeyError:
-                pass
+            self.known_elements[self.page].pop(k, None)
         else:
             # self.write_subdivision_result(elem, self.page, sub)
             if self.known_elements[self.page].get(k) is None or replace:

--- a/pdfnormalizer/app_geracao_dataset
+++ b/pdfnormalizer/app_geracao_dataset
@@ -67,10 +67,7 @@ class CustomGUIHandler(GUIHandler):
             self.known_elements[self.page] = {}
         k = self.get_elem_key(elem)
         if sub is None:
-            try:
-                self.known_elements[self.page].pop(k)
-            except KeyError:
-                pass
+            self.known_elements[self.page].pop(k, None)
         else:
             self.write_subdivision_result(elem, self.page, sub, splith=splith, splitv=splitv)
             if self.known_elements[self.page].get(k) is None or replace:

--- a/pdfnormalizer/utils.py
+++ b/pdfnormalizer/utils.py
@@ -5,6 +5,22 @@ def log(*args, **kwargs):
     from sys import stderr
     print(file=stderr, *args, **kwargs)
 
+def report_error(error: Exception, context: str = ""):
+    """Centralized error reporting function.
+
+    Must be used in all except/catch blocks instead of silently passing
+    or directly printing errors. Hook to Sentry here if/when available.
+    """
+    import traceback
+    from sys import stderr
+
+    msg = f"ERROR: {error}"
+    if context:
+        msg = f"{context}: {msg}"
+
+    print(msg, file=stderr)
+    traceback.print_exception(type(error), error, error.__traceback__, file=stderr)
+
 def array_to_data(array):
     from PIL import Image
     from io import BytesIO
@@ -147,14 +163,14 @@ class GUI():
         self.window.write_event_value(name, value)
     def tick(self, timeout=None):
         event, values = self.window.read(timeout=timeout)
-        handler = None
-        try:
-            handler = self.handler.__getattribute__(f'handle_{event}')
-            ret = handler(self, values)
-            if ret is not None:
-                return False
-        except AttributeError:
-            pass
+        handler = getattr(self.handler, f'handle_{event}', None)
+        if handler is not None:
+            try:
+                ret = handler(self, values)
+                if ret is not None:
+                    return False
+            except Exception as e:
+                report_error(e, context=f"GUI tick handler failed for event: {event}")
         log("GUI event: ", event, handler is not None, values)
         return True
 


### PR DESCRIPTION
**Assumptions**
- The global instructions explicitly forbid silent failures and empty `except` blocks.
- Since no explicit Sentry integration was found or specified in the codebase context, `report_error` simply forwards to `stderr` but is easily hookable.
- A `KeyError` when doing `pop` is an expected control-flow event, so using `pop(k, None)` is preferred over raising and catching.
- A missing GUI event handler is also expected, so checking `getattr(..., None)` is better than catching `AttributeError`, reserving the `try-except` block for true runtime errors inside the handlers.

**Alternatives Not Chosen**
- Keeping `try/except KeyError` and logging the error: Spamming logs for expected misses during iteration degrades log quality.
- Adding the `report_error` function inline inside each script: This duplicates code and violates DRY, so a centralized approach in `utils.py` was used instead.
- Ignoring `AttributeError` silently in GUI loop: Re-wrote the logic entirely so the catch block actually catches genuine errors while allowing expected missing handlers to pass natively.

**How To Pivot**
- If Sentry SDK or another telemetry system is introduced, simply modify `pdfnormalizer/utils.py`'s `report_error` function to capture exceptions using the new SDK.
- If the logs become too verbose for unhandled GUI events or minor errors, a severity level parameter can be added to `report_error`.

**Next Knobs**
- Implement `python -m unittest` properly by adding a `tests` directory.
- Hook `sentry-sdk` into `utils.py`.

---
*PR created automatically by Jules for task [5104952186492178235](https://jules.google.com/task/5104952186492178235) started by @lucasew*